### PR TITLE
[TAB-8][TAB-9][TAB-10] Add additional chains to renderer's support chains

### DIFF
--- a/lib/chains.js
+++ b/lib/chains.js
@@ -10,7 +10,8 @@ const chains = {
   421613:   {name: "Arbitrum Goerli",         slug: "arbitrum-goerli" },
   42170:    {name: "Arbitrum Nova",           slug: "arbitrum-nova", mainnet: true },
   3141:     {name: "Filecoin Hyperspace",     slug: "filecoin-hyperspace"},
-  314:      {name: "Filecoin Mainnet",        slug: "filecoin"},
+  314:      {name: "Filecoin Mainnet",        slug: "filecoin", mainnet: true},
+  11155111: {name: "Ethereum Sepolia",        slug: "ethereum-sepolia"},
 };
 
 export default chains;

--- a/lib/chains.js
+++ b/lib/chains.js
@@ -1,13 +1,16 @@
 const chains = {
-  1:        {name: "Ethereum Mainnet",  slug: "ethereum", mainnet: true},
-  5:        {name: "Ethereum Goerli",   slug: "ethereum-goerli"},
-  10:       {name: "Optimism",          slug: "optimism", mainnet: true},
-  69:       {name: "Optimism Kovan",    slug: "optimism-kovan"},
-  137:      {name: "Polygon Mainnet",   slug: "polygon", mainnet: true},
-  420:      {name: "Optimism Goerli",   slug: "optimism-goerli"},
-  80001:    {name: "Polygon Mumbai",    slug: "polygon-mumbai" },
-  42161:    {name: "Arbitrum",          slug: "arbitrum", mainnet: true },
-  421613:   {name: "Arbitrum Rinkeby",  slug: "arbitrum-goerli" }
+  1:        {name: "Ethereum Mainnet",        slug: "ethereum", mainnet: true},
+  5:        {name: "Ethereum Goerli",         slug: "ethereum-goerli"},
+  10:       {name: "Optimism",                slug: "optimism", mainnet: true},
+  69:       {name: "Optimism Kovan",          slug: "optimism-kovan"},
+  137:      {name: "Polygon Mainnet",         slug: "polygon", mainnet: true},
+  420:      {name: "Optimism Goerli",         slug: "optimism-goerli"},
+  80001:    {name: "Polygon Mumbai",          slug: "polygon-mumbai" },
+  42161:    {name: "Arbitrum",                slug: "arbitrum", mainnet: true },
+  421613:   {name: "Arbitrum Goerli",         slug: "arbitrum-goerli" },
+  42170:    {name: "Arbitrum Nova",           slug: "arbitrum-nova", mainnet: true },
+  3141:     {name: "Filecoin Hyperspace",     slug: "filecoin-hyperspace"},
+  314:      {name: "Filecoin Mainnet",        slug: "filecoin"},
 };
 
 export default chains;


### PR DESCRIPTION
[TAB-8] [TAB-9] [TAB-10]

This PR adds support for several chains: Filecoin, Filecoin Hyperspace, Arbirum Nova, and Ethereum Sepolia.

It also fixes an issue whereby Arbitrum Goerli was called Arbitrum Rinkeby. 